### PR TITLE
Add progress bar to encoder with `tqdm`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -59,6 +59,7 @@ install_requires =
     importlib-metadata; python_version<"3.8"
     numpy>=1.21.0
     click>=8.0.1
+    tqdm
 
 
 [options.packages.find]

--- a/src/drfp/fingerprint.py
+++ b/src/drfp/fingerprint.py
@@ -1,4 +1,4 @@
-from typing import Any, Iterable, List, Tuple, Set, Dict, Union, Mapping
+from typing import Any, Iterable, List, Tuple, Set, Dict, Union, Mapping, Optional
 from collections import defaultdict
 from hashlib import blake2b
 import numpy as np

--- a/src/drfp/fingerprint.py
+++ b/src/drfp/fingerprint.py
@@ -1,4 +1,4 @@
-from typing import Iterable, List, Tuple, Set, Dict, Union
+from typing import Any, Iterable, List, Tuple, Set, Dict, Union, Mapping
 from collections import defaultdict
 from hashlib import blake2b
 import numpy as np


### PR DESCRIPTION
I'm encoding the [Rhea](https://www.rhea-db.org/) reactions with `drfp` right now and it's taking more than 10 seconds, so naturally I'd like to see how much longer it will take using a progress bar. This PR adds a progress bar with `tqdm`. 

There was a strange bit of code before that I changed `for _, x in enumerate(X):` that didn't actually take advantage of the enumeration itself. This could have been replaced with `iter(X)` if the goal was just to turn it into an iterator, but also using `tqdm` gets the job done the same.